### PR TITLE
Ensure long running tasks don’t block execution

### DIFF
--- a/lib/nschedule.js
+++ b/lib/nschedule.js
@@ -100,9 +100,8 @@ Scheduler.prototype._dispatch = function(){
             self._onComplete(task, behavior);
             self._recompute();
         });
-    } else {
-        this._recompute();        
     }
+    this._recompute();
 }
 
 // When a task has finished, remove from the active set and reschedule


### PR DESCRIPTION
Previously scheduled tasks are blocked from executing after a long running task is dispatched until either:
a) The task is complete, or
b) A new task is added.

This ensures that previously scheduled tasks can still be dispatched while another task is running.
