### PR TITLE
Added options parameter, with optional verbose

### DIFF
--- a/lib/nschedule.js
+++ b/lib/nschedule.js
@@ -2,6 +2,7 @@
 // A periodic task scheduler with concurrency limits.
 // ----------------------------------------------------------------------------
 var PriorityQueue = require('priorityqueuejs');
+var _ = require('lodash')
 var Task = require('./task.js');
 
 // ----------------------------------------------------------------------------
@@ -26,9 +27,17 @@ Scheduler.prototype._timerID = null;
 //
 //  concurrency:    The number of tasks that can execute concurrently.
 // ----------------------------------------------------------------------------
-function Scheduler(concurrency){
+function Scheduler(opts){
+    if(_.isNumber(opts)) {
+        opts = { concurrency: opts }
+    }
+    opts = _.defaults(opts, {
+        concurrency: 1,
+        verbose: false
+    })
     this._active = [];
-    this._concurrency = concurrency || 1;
+    this._concurrency = opts.concurrency;
+    this._verbose = opts.verbose;
     this._pending = new PriorityQueue(function(a, b) {
             return b.waitRemaining() - a.waitRemaining();
         });    
@@ -62,7 +71,9 @@ Scheduler.prototype.add = function(interval, action, behavior){
 Scheduler.prototype._recompute = function(){
     // Do nothing if there are no tasks.
     if(this._pending.isEmpty()){
-        console.log("No more tasks.");
+        if(this._verbose) {
+            console.log("No more tasks.");
+        }
         return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
-    "name": "nschedule",
-    "description": "Task scheduler with concurrency limits.",
-    "author": "Thomas Bratt",
-    "license" : "MIT",
-    "version": "0.3.0",
-    "private": false,
-    "main": "./lib/nschedule.js",
-    "dependencies": {
-        "priorityqueuejs": "0.1.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/thomasbratt/NSchedule.git"
-    },
-    "keywords": [
-        "concurrency",
-        "poller",
-        "queue",
-        "scheduler",
-        "task",
-        "timer",
-        "worker"
-    ]
+  "name": "nschedule",
+  "description": "Task scheduler with concurrency limits.",
+  "author": "Thomas Bratt",
+  "license": "MIT",
+  "version": "0.3.0",
+  "private": false,
+  "main": "./lib/nschedule.js",
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "priorityqueuejs": "0.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thomasbratt/NSchedule.git"
+  },
+  "keywords": [
+    "concurrency",
+    "poller",
+    "queue",
+    "scheduler",
+    "task",
+    "timer",
+    "worker"
+  ]
 }


### PR DESCRIPTION
I added a "verbose" option to disable the "No more tasks." logging. I changed the constructor method to use an options parameter instead. However, it's backward compatible with the current implementation where simply passing a number will work as well. These all works:

```js
new Scheduler(1)
new Scheduler({ concurrency: 1 })
new Scheduler({ concurrency: 1, verbose: true })
```

Reference to issue #3 